### PR TITLE
Adding capability to remove authors without contribuition

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ The same, but to a batch of repositories listed in the `repos.txt` file:
 ./git-analysis.py -s 11/15/2021 -e 12/15/2021 -rf repos.txt
 ```
 
+### Filter Contributors
+
+The result can be filter to contributors with activity. Use the `-c` to file the result.
+
+```
+./git-analysis.py -rf repos.txt -c
+```
 ### Formatting the results
 
 The results can be formatted as `csv`, `json`, or a `markdown` table. The default is `csv`. Use the `-f` flag to control the output format.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The same, but to a batch of repositories listed in the `repos.txt` file:
 
 ### Filter Contributors
 
-The result can be filter to contributors with activity. Use the `-c` to file the result.
+Results can be filter to contributors with activity. Use the `-c` to file the result.
 
 ```
 ./git-analysis.py -rf repos.txt -c

--- a/git-analysis.py
+++ b/git-analysis.py
@@ -12,6 +12,7 @@ class GitLogsParser:
         @param username: an optional username of interest.  if not present, we report all contributing users
         @param exclusions: a list of files to exclude from analysis.  wild cards accepted, e.g. ['foo.csv', '*.zip', '*.jpg']
         @param verbose: whether to output debugging info.  defaults to False.
+        @param clean: remove contributors without any contribuition.  defaults to False.
         """
 
         self.repository = repo
@@ -217,7 +218,7 @@ if __name__ == "__main__":
             os.chdir(repo_dir) # navigate into this repository's directory
             subprocess.run(['git', 'pull'], capture_output=True) # clone the code from github
 
-        git_logs_parser = GitLogsParser(repo=repo_dir, start=args.start, end=args.end, username=args.user, verbose=args.verbose)
+        git_logs_parser = GitLogsParser(repo=repo_dir, start=args.start, end=args.end, username=args.user, verbose=args.verbose, clean=args.clean)
         results = git_logs_parser.parse()
         output = git_logs_parser.format_results(results, args.format)
         print(output)

--- a/git-analysis.py
+++ b/git-analysis.py
@@ -3,7 +3,7 @@
 import os, sys, subprocess, argparse, datetime, shlex, re
 
 class GitLogsParser:
-    def __init__(self, repo, start, end, username, exclusions=[], repofile=None, verbose=False):
+    def __init__(self, repo, start, end, username, exclusions=[], repofile=None, verbose=False, clean=False):
         """
         Initialize the git logs parser for a given repository
         @param repo: the path to the repository of interest.
@@ -21,6 +21,7 @@ class GitLogsParser:
         self.username = username
         self.exclusions = exclusions
         self.verbose = verbose
+        self.clean = clean
 
         # go into the selected repository directory, if any
         if self.repository:
@@ -91,7 +92,10 @@ class GitLogsParser:
                 entry['insertions'] += int(match.group(2))
                 entry['deletions'] += int(match.group(3))
             # add this user's stats to the list
-            stats.append(entry)
+            if(self.clean and (entry['merges'] == 0 and entry['commits'] == 0 and entry['insertions'] == 0 and entry['deletions'] == 0 and entry['files'] == 0)):
+                pass
+            else:
+                stats.append(entry)
             # self.verboseprint('Entry: ', entry) # only printed when in verbose mode
         return stats
 
@@ -176,6 +180,7 @@ if __name__ == "__main__":
     parser.add_argument("-x", "--exclusions", help='A comma-separated string of files to exclude, e.g. --excusions "foo.zip, *.jpg, *.json" ', default=','.join(exclusions))
     parser.add_argument("-f", "--format", help="The format in which to output the results", default='csv', choices=['csv', 'json', 'markdown'])
     parser.add_argument("-v", "--verbose", help="Whether to output debugging info", default=False, action="store_true")
+    parser.add_argument("-c", "--clean", help="Remove contributors without any contribuition", default=False, action="store_true")
     args = parser.parse_args()
 
 


### PR DESCRIPTION
When using this tool on larger projects it shows authors that used to contribute in the past with zero for their activity when setting a time scale, so I added an option to use in order to filter them.
Using `-c` or `--clean` to remove those authors out of the report.